### PR TITLE
Adding Caller Id Features

### DIFF
--- a/Radio.cs
+++ b/Radio.cs
@@ -150,6 +150,7 @@ namespace rc2_core
         public string Description { get; set; } = "";
         public string ZoneName { get; set; } = "";
         public string ChannelName { get; set; } = "";
+        public string CallerId { get; set; } = "";
         public RadioState State { get; set; } = RadioState.Disconnected;
         public ScanState ScanState { get; set; } = ScanState.NotScanning;
         public PriorityState PriorityState {get; set;} = PriorityState.NoPriority;


### PR DESCRIPTION
This pull request introduces a small enhancement to the `RadioStatus` class in `Radio.cs`. The change adds a new `CallerId` property to the class, which will allow tracking or displaying the caller's identification.

* [`Radio.cs`](diffhunk://#diff-2429ee60f6d313a4d085429638fe52b5362b713457eaf6f1350530594779b0e1R153): Added a `CallerId` property of type `string` to the `RadioStatus` class.