### PR TITLE
fix(core): respect radio rx-only mode for WebRTC peers

### DIFF
--- a/RC2Server.cs
+++ b/RC2Server.cs
@@ -82,6 +82,7 @@ namespace rc2_core
             // Set up the WebRTC handler
             wss.AddWebSocketService<WebRTCPeer>("/rtc", (peer) =>
             {
+                peer.RxOnly = radio.RxOnly;
                 peer.TxCallback += TxAudioCallback;
                 peer.TxAudioSamplerate = txAudioSampleRate;
                 peer.RTCFormatCallback += OnWebRTCFormats;

--- a/Radio.cs
+++ b/Radio.cs
@@ -256,7 +256,7 @@ namespace rc2_core
             Status.Name = name;
             Status.Description = desc;
             // Set RX Only
-            RxOnly = true;
+            RxOnly = rxOnly;
             // Create a softkey list
             if (softkeys != null) 
             { 


### PR DESCRIPTION
This fixes RX-only propagation in rc2-core.

Currently the base Radio constructor forces `RxOnly = true`, and WebRTC peers are not given the radio's RX-only state. This causes normal TX-capable radios and receive-only stream radios to share incorrect WebRTC TX/RX behavior.

Changes:
- Preserve the `rxOnly` constructor argument in `Radio`
- Pass `radio.RxOnly` into each `WebRTCPeer`

Validation:
- `dotnet build rc2-core.csproj`